### PR TITLE
Show JSON parsing errors on member page

### DIFF
--- a/memberscr.js
+++ b/memberscr.js
@@ -7,7 +7,10 @@ function on404(result){
     $("h3.memberprons").text("404 user not found");
 }
 
-function onGet(result){
+function onGet(result, textStatus, errorThrown){
+    if (errorThrown) {
+        $("h1").text(`There was an error! ${errorThrown}`);
+    }
 
     // name
     $("h1.membername").text(result["name"]);


### PR DESCRIPTION
If someone makes a mistake while making their JSON file and it can't be parsed, it will now show that error on the page.