### PR TITLE
Make `"socials"` and `"projects"` fields optional for member JSON

### DIFF
--- a/memberscr.js
+++ b/memberscr.js
@@ -17,30 +17,34 @@ function onGet(result){
 
     // fill in as many social media accounts
     // as the member specified
-    for (var i = 0; i < result["socials"].length; i++){
-        var s = result["socials"][i];
-        
-        var l = $("<a>");
-        l.attr("href", s);
-        l.text(s);
-        l.insertBefore("p.memberbio");
-        $("<br>").insertBefore("p.memberbio");
+    if (result["socials"]) {
+        for (var i = 0; i < result["socials"].length; i++){
+            var s = result["socials"][i];
+
+            var l = $("<a>");
+            l.attr("href", s);
+            l.text(s);
+            l.insertBefore("p.memberbio");
+            $("<br>").insertBefore("p.memberbio");
+        }
     }
 
     // bio
     $("p.memberbio").text(result["bio"]);
 
     // list projects
-    for (var j = 0; j < result["projects"].length; j++){
-        var curpro = result["projects"][j];
-        var cell = $("<a>");
-        cell.attr("href",  curpro["website"]);
-        cell.text(curpro["name"]);
-        cell.insertBefore("div.memberbot");
-        var c2 = $("<span>");
-        c2.text(" - " + curpro["description"]);
-        c2.insertBefore("div.memberbot");
-        $("<br>").insertBefore("div.memberbot");
+    if (result["projects"]) {
+        for (var j = 0; j < result["projects"].length; j++){
+            var curpro = result["projects"][j];
+            var cell = $("<a>");
+            cell.attr("href",  curpro["website"]);
+            cell.text(curpro["name"]);
+            cell.insertBefore("div.memberbot");
+            var c2 = $("<span>");
+            c2.text(" - " + curpro["description"]);
+            c2.insertBefore("div.memberbot");
+            $("<br>").insertBefore("div.memberbot");
+        }
     }
 }
 


### PR DESCRIPTION
Before, if you left out the `"socials"` or `"projects"` fields, it would give an error. If you wanted to have no socials or no projects, you had to give it an empty array. Now, you can omit any of the fields, which I think is friendlier to members adding their own pages.