### PR TITLE
Add information to the website, resolve #13

### DIFF
--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -11,7 +11,6 @@
     "attr-no-duplication": true,
     "title-require": true,
     "attr-unsafe-chars": true,
-    "href-abs-or-rel": true,
     "html-lang-require": true,
     "input-requires-label": true,
     "tagname-specialchars": true,

--- a/index.html
+++ b/index.html
@@ -6,7 +6,12 @@
 </head>
 <body>
     <div class="main">
-        <h1>ObieSource</h1>
-        <a href="/membersdir.html">Browse our members directory!</a>
+        <h1>ObieSource: Oberlin Open Source Club</h1>
+        <p>
+            ObieSource meets on Saturdays at the King second floor lounge at 5:00 PM!
+            Anyone is welcome to join, no matter how much or little coding experience you have.
+        </p>
+        <p><a href="/membersdir.html">Browse our members directory!</a></p>
+        <p><a href="https://github.com/ObieSource">See our projects on GitHub!</a></p>
     </div>
 </body>


### PR DESCRIPTION
I also removed the `html-abs-or-rel` lint rule. Since we set it to `true`, HTMLHint interprets that as meaning our URLs must all be relative. That means we can't link to outside websites (GitHub in this case).