### PR TITLE
add open graph metadata to all pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,6 +3,11 @@
     <title>About ObieSource</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/style.css">
+
+    <meta property="og:title" content="About ObieSource">
+    <meta property="og:description" content="Open Source is a programming philosophy that work and ownership of projects should be decentralized and community-based.">
+    <meta property="og:url" content="https://obiesource.github.io/about.html">
+    <meta property="og:type" content="article">
 </head>
 <body>
 	<!-- Attempt at a navbar without bootstrap API lol -->

--- a/contact.html
+++ b/contact.html
@@ -3,6 +3,11 @@
     <title>ObieSource</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/style.css">
+
+    <meta property="og:title" content="Contact - ObieSource">
+    <meta property="og:description" content="We don't yet have an official ObieSource email, so to get in contact with the club, you can email Ike Osenberg or William Knowles-Kellett.">
+    <meta property="og:url" content="https://obiesource.github.io/contact.html">
+    <meta property="og:type" content="article">
 </head>
 <body>
 	<!-- Attempt at a navbar without bootstrap API lol -->

--- a/index.html
+++ b/index.html
@@ -3,6 +3,11 @@
     <title>ObieSource</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/style.css">
+
+    <meta property="og:title" content="ObieSource">
+    <meta property="og:description" content="Oberlin Open Source Club">
+    <meta property="og:url" content="https://obiesource.github.io/">
+    <meta property="og:type" content="website">
 </head>
 <body>
 	<!-- Attempt at a navbar without bootstrap API lol -->

--- a/member.html
+++ b/member.html
@@ -4,6 +4,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/style.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <meta property="og:title" content="Member Page">
+    <meta property="og:description" content="Member of ObieSource">
+    <meta property="og:type" content="profile">
 </head>
 <body>
     <!-- Attempt at a navbar without bootstrap API lol -->

--- a/membersdir.html
+++ b/membersdir.html
@@ -4,6 +4,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/style.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <meta property="og:title" content="ObieSource Members Directory">
+    <meta property="og:description" content="Current members of the ObieSource club">
+    <meta property="og:url" content="https://obiesource.github.io/membersdir.html">
+    <meta property="og:type" content="website">
 </head>
 <body>
     <!-- Attempt at a navbar without bootstrap API lol -->


### PR DESCRIPTION
Here are some good links that explain the role of open graph protocol:

https://ahrefs.com/blog/open-graph-meta-tags/
https://developers.facebook.com/docs/sharing/webmasters/
https://ogp.me/

There may be some ways to improve this, such as modifying some of these tags using javascript (for example, which member is being viewed).